### PR TITLE
utf8 characters in code require the 'utf8' pragma

### DIFF
--- a/lib/Acme/CPANAuthors/Acme/CPANAuthors/Authors.pm
+++ b/lib/Acme/CPANAuthors/Acme/CPANAuthors/Authors.pm
@@ -1,6 +1,9 @@
 package Acme::CPANAuthors::Acme::CPANAuthors::Authors;
 use strict;
 use warnings;
+use utf8;
+
+=encoding utf-8
 
 =head1 NAME
 


### PR DESCRIPTION
I got this report, caused by some other CPANAuthors module(s) with undeclared wide characters -- http://www.cpantesters.org/cpan/report/f3350cfa-ef0b-11e2-90ca-df1f445abc7e
